### PR TITLE
[DDH-35] feat: integrate overview reporter page

### DIFF
--- a/src/components/OverviewStatusCard.jsx
+++ b/src/components/OverviewStatusCard.jsx
@@ -2,7 +2,7 @@ import { ApprovedIcon, PendingIcon, RejectedIcon, TotalIcon } from "@/icons";
 
 const StatusIcon = ({ status }) => {
   switch (status) {
-    case "pending":
+    case "waiting_for_reviewing":
       return <PendingIcon />;
     case "approved":
       return <ApprovedIcon />;
@@ -15,7 +15,7 @@ const StatusIcon = ({ status }) => {
 
 const statusName = (status) => {
   switch (status) {
-    case "pending":
+    case "waiting_for_reviewing":
       return "รอการตรวจสอบ";
     case "approved":
       return "รายงานที่ได้รับการอนุมัติ";

--- a/src/features/reporter/components/ReportTable.jsx
+++ b/src/features/reporter/components/ReportTable.jsx
@@ -1,31 +1,39 @@
 "use client";
 
 import Link from "next/link";
-import { MOCK_REPORT_LIST } from "../constants";
 
 import { Badge, Table, UnstyledButton } from "@mantine/core";
 import { Report } from "@/icons";
 
 const getBadgeStatus = (status) => {
   switch (status) {
-    case "รอการอนุมัติ":
+    case "pending":
       return "yellow";
-    case "ไม่อนุมัติ":
+    case "rejected":
       return "red";
-    case "อนุมัติ":
+    case "approved":
       return "green";
     default:
       return "gray";
   }
 };
 
-export const ReportTable = () => {
-  const rows = MOCK_REPORT_LIST.map((report) => (
-    <Table.Tr key={report.id}>
+const getStatusText = (status) => {
+  switch (status) {
+    case "pending": return "รอการอนุมัติ"
+    case "rejected": return "ไม่อนุมัติ"
+    case "approved": return "อนุมัติ"
+    default: return status
+  }
+}
+
+export const ReportTable = ({data = []}) => {
+  const rows = data.map((report, idx) => (
+    <Table.Tr key={`${report.template_name}-${idx}`}>
       <Table.Td>{report.date}</Table.Td>
-      <Table.Td>{report.count}</Table.Td>
-      <Table.Td>{report.times}</Table.Td>
-      <Table.Td>{report.name}</Table.Td>
+      <Table.Td>{report.order}</Table.Td>
+      <Table.Td>{report.time}</Table.Td>
+      <Table.Td>{report.template_name}</Table.Td>
       <Table.Td>
         <Badge
           variant="light"
@@ -33,14 +41,14 @@ export const ReportTable = () => {
           size="lg"
           style={{ fontWeight: 400 }}
         >
-          {report.status}
+          {getStatusText(report.status)}
         </Badge>
       </Table.Td>
       <Table.Td>
         <UnstyledButton
           component={Link}
           className="col mx-auto items-center text-xs"
-          href={`#${report.id}`}
+          href={`#${idx}`}
         >
           <Report className="size-5" />
           ดูรายงาน

--- a/src/features/reporter/constants/index.js
+++ b/src/features/reporter/constants/index.js
@@ -81,20 +81,20 @@ export const DISASTERS_REPORT_SELECT = [
 export const SAMPLE_REPORT = [
   {
     id: 1,
-    src: "https://images.pexels.com/photos/1459505/pexels-photo-1459505.jpeg?auto=compress&cs=tinysrgb&dpr=1&w=500"
+    src: "https://images.pexels.com/photos/1459505/pexels-photo-1459505.jpeg?auto=compress&cs=tinysrgb&dpr=1&w=500",
   },
   {
     id: 2,
-    src: "https://upload.wikimedia.org/wikipedia/commons/0/0f/Eiffel_Tower_Vertical.JPG"
+    src: "https://upload.wikimedia.org/wikipedia/commons/0/0f/Eiffel_Tower_Vertical.JPG",
   },
   {
     id: 3,
-    src: "https://media.istockphoto.com/id/1193723594/photo/fujiyoshida-japan-at-chureito-pagoda-and-mt-fuji-in-the-spring-with-cherry-blossoms.jpg?s=612x612&w=0&k=20&c=O5Oy6Bxa7rJs6eqVu4h85OxDd-yBnUVfJ_cAyt5P6iY="
+    src: "https://media.istockphoto.com/id/1193723594/photo/fujiyoshida-japan-at-chureito-pagoda-and-mt-fuji-in-the-spring-with-cherry-blossoms.jpg?s=612x612&w=0&k=20&c=O5Oy6Bxa7rJs6eqVu4h85OxDd-yBnUVfJ_cAyt5P6iY=",
   },
   {
     id: 4,
-    src: "https://cdn.pixabay.com/photo/2022/10/09/12/07/plant-7508987_640.jpg"
-  }
+    src: "https://cdn.pixabay.com/photo/2022/10/09/12/07/plant-7508987_640.jpg",
+  },
 ];
 
 export const MOCK_OVERVIEW_STATUS = [
@@ -127,4 +127,21 @@ export const REPORTER_MENUS = [
     icon: Template,
     value: 2,
   },
-]
+];
+
+export const OVERVIEW_STATUS = [
+  "waiting_for_reviewing",
+  "approved",
+  "rejected",
+  "total",
+];
+
+export const INITIAL_OVERVIEW_DATA = {
+  summary_numbers: {
+    waiting_for_reviewing: 0,
+    approved: 0,
+    rejected: 0,
+    total: 0,
+  },
+  report_table: [],
+};

--- a/src/features/reporter/constants/queryKeys.js
+++ b/src/features/reporter/constants/queryKeys.js
@@ -1,0 +1,1 @@
+export const LIST_REPORT = "list_report";

--- a/src/features/reporter/containers/ReporterHomeContainer.jsx
+++ b/src/features/reporter/containers/ReporterHomeContainer.jsx
@@ -5,18 +5,25 @@ import { Button, Input, UnstyledButton } from "@mantine/core";
 
 import dayjs from '@/lib/helpers/dayjs'
 import { useAuthContext } from '@/lib/providers/auth';
-import { MOCK_OVERVIEW_STATUS } from "../constants";
+import { INITIAL_OVERVIEW_DATA, OVERVIEW_STATUS } from "../constants";
 
 import { OverviewStatusCard } from '@/components';
 import { CreateReportModal, ReportTable } from "../components";
 import { AddIcon, Filter, Search, Sort } from "@/icons";
+import { useListReports } from "../services";
+import { useMemo } from "react";
 
 export const ReporterHomeContainer = () => {
   const { data } = useAuthContext()
+  const { data: reports } = useListReports(data?.province)
   const [
     createReportOpened,
     { open: openCreateReport, close: closeCreateReport },
   ] = useDisclosure(false);
+
+  const formattedReports = useMemo(() => {
+    return reports || INITIAL_OVERVIEW_DATA
+  }, [reports])
 
   return (
     <div className="max-w-[78.875rem] mx-auto">
@@ -27,8 +34,8 @@ export const ReporterHomeContainer = () => {
             {dayjs(data.date).format("DD MMMM BBBB")}
           </p>
           <div className="flex flex-row gap-5 mx-auto">
-            {MOCK_OVERVIEW_STATUS.map(({ total, status }) => (
-              <OverviewStatusCard key={status} total={total} status={status} />
+            {OVERVIEW_STATUS.map((status) => (
+              <OverviewStatusCard key={status} total={formattedReports?.summary_numbers?.[status]} status={status} />
             ))}
           </div>
         </div>
@@ -59,7 +66,7 @@ export const ReporterHomeContainer = () => {
           <div className="col gap-4">
             <div className="row items-center justify-between">
               <p className="text-xl font-medium">
-                ประวัติการจัดทำรายงานสาธารณภัยประจำวัน จังหวัดสุพรรณบุรี
+                ประวัติการจัดทำรายงานสาธารณภัยประจำวัน จังหวัด{data?.province}
               </p>
               <UnstyledButton className="row items-center text-sm gap-2 text-gray-900">
                 <Sort className="size-6 text-gray-600" />
@@ -67,7 +74,7 @@ export const ReporterHomeContainer = () => {
               </UnstyledButton>
             </div>
 
-            <ReportTable />
+            <ReportTable data={formattedReports?.report_table} />
           </div>
         </div>
       </div>

--- a/src/features/reporter/services/getListReports.js
+++ b/src/features/reporter/services/getListReports.js
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchAPI } from "@/lib/api";
+import { PROVINCES } from "@/constants";
+import { LIST_REPORT } from "../constants/queryKeys";
+
+const getListReports = async (province) => {
+  const provinceId = PROVINCES.findIndex((p) => p === province);
+
+  const { data } = await fetchAPI({
+    path: `/getListReport?province_id=${provinceId}`,
+    method: "GET",
+  });
+
+  return data;
+};
+
+export const useListReports = (province) => {
+  return useQuery({
+    queryKey: [LIST_REPORT, province],
+    queryFn: () => getListReports(province),
+  });
+};

--- a/src/features/reporter/services/index.js
+++ b/src/features/reporter/services/index.js
@@ -1,1 +1,2 @@
-export * from './reloadReport'
+export * from "./reloadReport";
+export * from "./getListReports";


### PR DESCRIPTION
Issues No. [DDH-35](https://www.notion.so/Integrate-Report-Home-Page-Overview-Status-and-Report-History-183e46eb29bb80259d88dc8b2df13d6a?pvs=4)

# Overview
- Add service getListReports and integrate on page overview

# Todo
- Might need to add redirect when detail report is finished

# UI
[screen-capture (11).webm](https://github.com/user-attachments/assets/158e7b22-6f74-4f25-903e-9cca406411e7)
