### PR TITLE
Fix: template component modal button and component preview

### DIFF
--- a/src/features/createLayout/SelectOutline.jsx
+++ b/src/features/createLayout/SelectOutline.jsx
@@ -13,7 +13,7 @@ import { BackIcon, NextIcon } from "@/icons";
 import { TemplateComponentModal } from "../template/components";
 
 const SelectOutline = () => {
-  const { selectedLayout, openSaveModal } = useContext(CreateLayoutContext);
+  const { selectedLayout, setSelectedLayout, openSaveModal } = useContext(CreateLayoutContext);
   const router = useRouter();
 
   const handleBackButton = () => {

--- a/src/features/template/components/ComponentCustomModal.jsx
+++ b/src/features/template/components/ComponentCustomModal.jsx
@@ -1,36 +1,42 @@
 "use client";
 
-import { Button } from "@mantine/core";
-import { useDisclosure } from "@mantine/hooks";
-
 import { ComponentPreview } from "./ComponentPreview";
 import { ComponentCustom } from "./ComponentCustom";
 import { Modal } from "@/components";
+import { DISASTERS } from "@/constants";
 
-export const CustomComponentModal = ({
-  disaster = "อุทกภัย",
-  type = "table",
+export const ComponentCustomModal = ({
+  disaster = "flood",
+  isTable,
+  componentData,
+  opened,
+  close,
+  proceedAction
 }) => {
-  const [opened, { open, close }] = useDisclosure(false);
+  const disasterText = DISASTERS.find((d) => d.value === disaster)?.text;
 
   return (
     <>
       <Modal
         opened={opened}
         close={close}
-        title={`ส่วนประกอบข้อมูลกลุ่ม${disaster}`}
+        title={`ส่วนประกอบข้อมูลกลุ่ม${disasterText}`}
         cancelText="เลือกชุดข้อมูลใหม่"
+        cancelAction={close}
         proceedText="นำไปใช้"
+        proceedAction={proceedAction}
       >
         <div className="w-full min-w-[78.3125rem] h-[70vh] flex flex-row gap-20">
-          <ComponentPreview text={disaster} image="mock-component-1.svg" />
-          {type === "table" && <ComponentCustom />}
+          <ComponentPreview
+            text={disasterText}
+            image={
+              componentData?.mock_img_url ||
+              componentData?.empty_img_url
+            }
+          />
+          {isTable && <ComponentCustom />}
         </div>
       </Modal>
-
-      <Button variant="default" onClick={open}>
-        Component Modal
-      </Button>
     </>
   );
 };

--- a/src/features/template/components/TemplateComponentModal.jsx
+++ b/src/features/template/components/TemplateComponentModal.jsx
@@ -8,8 +8,7 @@ import { Modal } from "@/components";
 import { useGetListComponents } from "@/services";
 import { useSelectTemplateComponent } from "../hook/useSelectTemplateComponent";
 import {
-  ComponentCustom,
-  ComponentPreview,
+  ComponentCustomModal,
   DisasterComponentList,
   DisasterComponentOptions,
   DisasterTypeBoxList,
@@ -173,18 +172,14 @@ export const TemplateComponentModal = () => {
               ) : null}
 
               {step === 2 && option && selectedTempComponent ? (
-                <div className="w-full min-w-[78.3125rem] h-[70vh] flex flex-row gap-20">
-                  <div className="w-[54rem]">
-                    <ComponentPreview
-                      text={`ตัวอย่างข้อมูล${option?.name}`}
-                      image={
-                        selectedTempComponent?.data?.mock_img_url ||
-                        selectedTempComponent?.data?.empty_img_url
-                      }
-                    />
-                  </div>
-                  <ComponentCustom />
-                </div>
+                <ComponentCustomModal
+                  disaster={selectedDisaster}
+                  opened={true}
+                  close={onCancel}
+                  proceedAction={onProceed}
+                  isTable={selectedTempComponent?.data?.name?.includes('ตาราง')}
+                  componentData={selectedTempComponent?.data}
+                />
               ) : null}
             </>
           )}

--- a/src/styles/Button.module.css
+++ b/src/styles/Button.module.css
@@ -1,5 +1,4 @@
 .root {
-  background-color: white;
   border-radius: 8px !important;
   font-size: 16px;
   font-weight: 500;


### PR DESCRIPTION
# Overview
Fix 3 bugs
1. ปุ่มดำเนินการต่อ background เป็นสีขาว (เฉพาะ build version)
2. ใช้ ComponentCustomModal แทนที่จะใช้​ ComponentCustom ตรงๆ บน TemplateComponentModal
3. ปุ่มย้อนกลับ หลังจากที่เลือก layout ไปแล้วไม่ทำงาน

# UI from Implement
1-2:
before: 
ปุ่มขวาล่างมันหาย เพราะ bg ขาว + text ขาว
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/6e89ff0b-144a-4704-8450-d4327cb5a152" />
ตาม flow คือต้องโชว์แต่รูป เราจะโชว์พวก input เฉพาะถ้าเป็น type table
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/3879394d-9005-441b-80f1-75c73c513c9c" />


after:
ปุ่มกลับมาแล้ว + แก้ข้อ 2 โดยการใช้ ComponentCustomModal  ซึ่ง implement ไว้แล้วแต่ไม่ได้เรียกใช้
https://github.com/user-attachments/assets/492c1289-6999-43e9-8957-2f20cd61169b


3:
แก้ปุ่มย้อนกลับให้มันทำงานได้
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/1d3058d6-db71-4bbd-ba55-d0cb73f2d133" />
