### PR TITLE
[DDH-57] fix: report remove custom component bg

### DIFF
--- a/src/features/reporter/components/ReporterCustomizableComponent.jsx
+++ b/src/features/reporter/components/ReporterCustomizableComponent.jsx
@@ -10,7 +10,7 @@ export const ReporterCustomizableComponent = ({ box, onClick, imgUrl }) => {
     <div
       onClick={onClick}
       className={clsx(
-        "absolute flex items-center justify-center hover:outline hover:outline-blue-500 cursor-pointer bg-gray-200 hover:bg-white",
+        "absolute flex items-center justify-center hover:outline hover:outline-blue-500 cursor-pointer hover:bg-white",
         imgUrl ? "box-parent-edit" : "box-parent-add"
       )}
       style={{
@@ -20,10 +20,8 @@ export const ReporterCustomizableComponent = ({ box, onClick, imgUrl }) => {
         left: `calc(${box.left}*${TEMPLATE_WIDTH}px)`,
       }}
     >
-      {imgUrl ? (
+      {imgUrl && (
         <Image className="w-full h-full" src={imgUrl} fit="contain" />
-      ) : (
-        "+"
       )}
       <Button className="box-button-add button-in-layout" variant="outline">
         + เพิ่ม


### PR DESCRIPTION
Issues No. [DDH-57](https://www.notion.so/UI-Report-Customize-component-Change-backgrou-194e46eb29bb80eb8b13ca8a7a45d0f3?pvs=4)

# Overview
- remove report custom component background and + text

# UI from Implement
[screen-capture (19).webm](https://github.com/user-attachments/assets/30a42a55-b09c-4baf-a4a2-975810883bb6)
