### PR TITLE
[DDH-71] fix: integrate create report with custom component

### DIFF
--- a/src/features/reporter/containers/ReporterCreateContainer.jsx
+++ b/src/features/reporter/containers/ReporterCreateContainer.jsx
@@ -6,7 +6,12 @@ import { useDisclosure } from "@mantine/hooks";
 
 import { useReloadReport } from "../services";
 
-import { RefreshReportModal, ReporterComponentModal, ReporterCustomizableComponent, CustomVisualizeComponentModal } from "../components";
+import {
+  RefreshReportModal,
+  ReporterComponentModal,
+  ReporterCustomizableComponent,
+  CustomVisualizeComponentModal,
+} from "../components";
 import { Button, Image } from "@mantine/core";
 import { Refresh, Multiplier1, Multiplier15, Multiplier2 } from "@/icons";
 import { useAuthContext } from "@/lib/providers/auth";
@@ -131,10 +136,14 @@ export const ReporterCreateContainer = () => {
       {
         params: {
           img_url: reloadedReport?.data?.img_url,
-          template_id: 1,
-          date: data?.date,
+          template_id: id,
+          date: data?.date ? dayjs(data?.date).format("YYYY-MM-DD") : undefined,
           province_id: data?.province.id,
           name: templateName,
+          customizable_component: customComponents?.map((comp) => ({
+            box_id: comp?.box?.box_id,
+            img_url: comp?.imgUrl,
+          })) || [],
         },
       },
       {


### PR DESCRIPTION
Issues No. [DDH-71](https://www.notion.so/Integrate-Report-Fix-report-not-reflect-custom-component-197e46eb29bb806e83e0eab0c627872e?pvs=4)

# Overview
- Fix integrate create report with custom component

# UI from Implement
[screen-capture (21).webm](https://github.com/user-attachments/assets/f8a1d848-d85b-437e-8de7-b7db793b709b)
